### PR TITLE
Feature/add diagnostic logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,9 +40,10 @@ function release (client, err) {
   let tid
   if (this.options.idleTimeoutMillis) {
     tid = setTimeout(() => {
-      this.log('remove idle client')
+      this.log(`remove idle client ${client.clientId} caused by timeoutId ${tid}`)
       this._remove(client)
     }, this.options.idleTimeoutMillis)
+    this.log(`Set timeoutId ${tid} for client ${client.clientId}`);
   }
 
   this._idle.push(new IdleItem(client, tid))
@@ -135,6 +136,7 @@ class Pool extends EventEmitter {
     const waiter = this._pendingQueue.shift()
     if (this._idle.length) {
       const idleItem = this._idle.pop()
+      this.log(`Clearing timeoutId ${idleItem.timeoutId} for client ${idleItem.client.clientId}`);
       clearTimeout(idleItem.timeoutId)
       const client = idleItem.client
       client.release = release.bind(this, client)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-pool",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Connection pool for node-postgres",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
We're seeing in circleCI builds occasional errors that I've traced to idle timeouts firing for clients that have been handed out from the connection pool and are in use.  This added logging should let me track exactly what idle timeouts get set and exactly which ones get cleared successfully, and hopefully should add the needed data to our logs to reveal just how we're seeing timeouts on active clients.