### PR TITLE
Log something that's actually readable

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,10 +40,11 @@ function release (client, err) {
   let tid
   if (this.options.idleTimeoutMillis) {
     tid = setTimeout(() => {
-      this.log(`remove idle client ${client.clientId} caused by timeoutId ${tid}`)
+      this.log(`remove idle client ${client.clientId} caused by timeoutId ${tid.customId}`)
       this._remove(client)
     }, this.options.idleTimeoutMillis)
-    this.log(`Set timeoutId ${tid} for client ${client.clientId}`);
+    tid.customId = Math.random.toString();
+    this.log(`Set timeoutId ${tid.customId} for client ${client.clientId}`);
   }
 
   this._idle.push(new IdleItem(client, tid))
@@ -136,7 +137,7 @@ class Pool extends EventEmitter {
     const waiter = this._pendingQueue.shift()
     if (this._idle.length) {
       const idleItem = this._idle.pop()
-      this.log(`Clearing timeoutId ${idleItem.timeoutId} for client ${idleItem.client.clientId}`);
+      this.log(`Clearing timeoutId ${idleItem.timeoutId.customId} for client ${idleItem.client.clientId}`);
       clearTimeout(idleItem.timeoutId)
       const client = idleItem.client
       client.release = release.bind(this, client)


### PR DESCRIPTION
I went to check the results of the new logging and found that the return value from setTimeout just logs as [object Object].

That doesn't let me distinguish timeouts from each other so instead let's tack on some unique id number in a property and log that instead.